### PR TITLE
Added options to set wls_settings by extra resource

### DIFF
--- a/puppet/modules/easy_type/lib/easy_type/command_entry.rb
+++ b/puppet/modules/easy_type/lib/easy_type/command_entry.rb
@@ -15,10 +15,19 @@ class CommandEntry
 	def execute
 		normalized_command = RUBY_VERSION == "1.8.7" ? command.to_s : command.to_sym
 		if @@binding.methods.include?(normalized_command)
-			@@binding.send(normalized_command, *arguments)
+			@@binding.send(normalized_command, *normalized_arguments)
 		else
 			full_command = arguments.dup.unshift(command).join(' ') 
 			Puppet::Util::Execution.execute(full_command,:failonfail => true)
+		end
+	end
+
+	private
+	def normalized_arguments
+		if arguments.length > 1
+			arguments.join(' ')
+		else
+			arguments
 		end
 	end
 

--- a/puppet/modules/easy_type/lib/easy_type/script_builder.rb
+++ b/puppet/modules/easy_type/lib/easy_type/script_builder.rb
@@ -53,25 +53,31 @@ module EasyType
 		end
 
 		def <<(line)
-			raise ArgumentError, 'no command specified' unless last_command
-			last_command.arguments << line if line
+			catch(:no_last_command) do
+				check_last_command
+				last_command.arguments << line if line
+			end
 		end
 
 		#
 		# For backward compatibility
 		#
 		def line
-			raise ArgumentError, 'no command specified' unless last_command
-			last_command.arguments.join(' ')
+			catch(:no_last_command) do
+				check_last_command
+				last_command.arguments.join(' ')
+			end
 		end
 
 		#
 		# For backward compatibility
 		#
 		def line=(line)
-			raise ArgumentError, 'no command specified' unless last_command
-			last_command.arguments.clear
-			last_command.arguments << line.split(' ')
+			catch(:no_last_command) do
+				check_last_command
+				last_command.arguments.clear
+				last_command.arguments << line.split(' ')
+			end
 		end
 
 
@@ -104,6 +110,13 @@ module EasyType
 		end
 
 		private
+
+			def check_last_command
+				unless last_command
+					Puppet.debug 'no command specified'	
+					throw(:no_last_command)
+				end
+			end
 
 			def add_to_queue(queue, line, &block)
 				raise ArgumentError, 'block or line must be present' unless block or line

--- a/puppet/modules/orawls/lib/puppet/provider/wls_setting/yaml.rb
+++ b/puppet/modules/orawls/lib/puppet/provider/wls_setting/yaml.rb
@@ -1,0 +1,40 @@
+require 'easy_type'
+
+Puppet::Type.type(:wls_setting).provide(:yaml) do
+	include EasyType::Provider
+
+  desc "Manage wls settings through yaml file"
+
+  mk_resource_methods
+
+	def flush
+		merge_configuration
+		write_yaml	
+  end
+
+private
+
+	def merge_configuration
+		# Always write defaults because we cannot support more then one setting
+		resource.class.configuration.merge!({ 'default' => settings_for_resource})
+	end
+
+	def settings_for_resource
+		settings = resource.to_resource
+		settings = resource.to_hash.reject {|key, value| [:name, :provider, :loglevel].include?(key)}
+		stringify_keys(settings)
+	end
+
+	def write_yaml
+		open(resource.class.config_file, "w+") {|f| YAML.dump( resource.class.configuration, f)}
+	end
+
+	def stringify_keys(hash)
+		result = {}
+		hash.each do |key, value|
+			result[key.to_s] = value 
+		end
+		result
+	end
+
+end

--- a/puppet/modules/orawls/lib/puppet/type/wls_machine.rb
+++ b/puppet/modules/orawls/lib/puppet/type/wls_machine.rb
@@ -1,5 +1,6 @@
 require 'easy_type'
 require 'utils/wls_access'
+require 'utils/settings'
 require 'facter'
 
 module Puppet

--- a/puppet/modules/orawls/lib/puppet/type/wls_machine/sid.rb
+++ b/puppet/modules/orawls/lib/puppet/type/wls_machine/sid.rb
@@ -1,0 +1,10 @@
+newmetaparam(:sid) do
+  include EasyType
+
+  desc "The machine name"
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource['name']
+  end
+
+end

--- a/puppet/modules/orawls/lib/puppet/type/wls_setting.rb
+++ b/puppet/modules/orawls/lib/puppet/type/wls_setting.rb
@@ -1,0 +1,68 @@
+require 'easy_type'
+require 'yaml'
+require 'ruby-debug'
+
+module Puppet
+  newtype(:wls_setting) do
+    include EasyType
+
+    DEFAULT_FILE = "~/.wls_setting.yaml"
+
+    desc "This resource allows you to set the defaults for all other wls types"
+
+    to_get_raw_resources do
+      resources_from_yaml
+    end
+
+    parameter :name
+    property  :user
+    property  :domain
+    property  :domains_path
+    property  :connect_url
+    property  :admin_server
+
+    def self.configuration
+      @configuration
+    end
+
+  private
+
+    def self.resources_from_yaml
+      @configuration = read_from_yaml
+      normalize(@configuration)
+    end
+
+    def self.config_file
+      Pathname.new(DEFAULT_FILE).expand_path
+    end
+
+
+    def self.read_from_yaml
+      if File.exists?(config_file)
+        open(config_file){|f| YAML.load(f)}
+      else
+        Hash['default', {}]
+      end
+    end
+
+    private
+
+      def self.normalize(content)
+        normalized_content = []
+        content.each do | key, value|
+          value[:name] = key
+          normalized_content << with_hashified_keys(value)
+        end
+        normalized_content
+      end
+
+      def self.with_hashified_keys(hash)
+        result = {}
+        hash.each do |key, value|
+          result[key.to_sym] = value 
+        end
+        result
+      end
+
+  end
+end

--- a/puppet/modules/orawls/lib/puppet/type/wls_setting/admin_server.rb
+++ b/puppet/modules/orawls/lib/puppet/type/wls_setting/admin_server.rb
@@ -1,0 +1,11 @@
+newproperty(:admin_server) do
+  include EasyType
+
+  desc "the host name of the admin server"
+  defaultto 'localhost'
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource[self.name]
+  end
+
+end

--- a/puppet/modules/orawls/lib/puppet/type/wls_setting/connect_url.rb
+++ b/puppet/modules/orawls/lib/puppet/type/wls_setting/connect_url.rb
@@ -1,0 +1,11 @@
+newproperty(:connect_url) do
+  include EasyType
+
+  desc "The url to connect to"
+  defaultto 'http://localhost:7001'
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource[self.name]
+  end
+
+end

--- a/puppet/modules/orawls/lib/puppet/type/wls_setting/domain.rb
+++ b/puppet/modules/orawls/lib/puppet/type/wls_setting/domain.rb
@@ -1,0 +1,10 @@
+newproperty(:domain) do
+  include EasyType
+
+  desc "The WLS domain"
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource[self.name]
+  end
+
+end

--- a/puppet/modules/orawls/lib/puppet/type/wls_setting/domains_path.rb
+++ b/puppet/modules/orawls/lib/puppet/type/wls_setting/domains_path.rb
@@ -1,0 +1,10 @@
+newproperty(:domains_path) do
+  include EasyType
+
+  desc "TODO: Fill in the description"
+
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource[self.name]
+  end
+end

--- a/puppet/modules/orawls/lib/puppet/type/wls_setting/name.rb
+++ b/puppet/modules/orawls/lib/puppet/type/wls_setting/name.rb
@@ -1,0 +1,12 @@
+newparam(:name) do
+  include EasyType
+
+  desc "The name of the setting"
+
+  isnamevar
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource[self.name]
+  end
+
+end

--- a/puppet/modules/orawls/lib/puppet/type/wls_setting/user.rb
+++ b/puppet/modules/orawls/lib/puppet/type/wls_setting/user.rb
@@ -1,0 +1,10 @@
+newproperty(:user) do
+  include EasyType
+
+  desc "TODO: Fill in the description"
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource[self.name]
+  end
+
+end

--- a/puppet/modules/orawls/lib/utils/settings.rb
+++ b/puppet/modules/orawls/lib/utils/settings.rb
@@ -1,0 +1,26 @@
+require 'yaml'
+
+module Settings
+
+  def setting_for(key)
+    settings[key]
+  end
+
+  def configuration
+    @configuration ||= read_from_yaml
+  end
+
+  def settings
+    configuration['default']
+  end
+
+  def read_from_yaml
+    if File.exists?(config_file)
+      open(config_file){|f| YAML.load(f)}
+    else
+      Hash['default', {}]
+    end
+  end
+
+
+end

--- a/puppet/modules/orawls/lib/utils/wls_access.rb
+++ b/puppet/modules/orawls/lib/utils/wls_access.rb
@@ -12,18 +12,11 @@ end
 module Utils
   module WlsAccess
 
-
-  #   class QueryResults < Hash
-  #     def column_data(column_name)
-  #       fetch(column_name) do 
-  #         fail "Column #{column_name} not found in results. Results contain #{keys.join(',')}"
-  #       end
-  #     end
-  #   end
-
+    DEFAULT_FILE = "~/.wls_setting.yaml"
 
     def self.included(parent)
       parent.extend(WlsAccess)
+      parent.extend(Settings)
     end
 
     def wlst( content, parameters = {})
@@ -44,24 +37,28 @@ module Utils
 
     private
 
+      def config_file
+        Pathname.new(DEFAULT_FILE).expand_path
+      end
+
       def weblogicUser
-        Facter.value('override_weblogic_user') || "oracle"
+        setting_for('user') || "oracle"
       end
 
       def weblogicDomain
-        Facter.value('weblogic_domain')
+        setting_for('domain')
       end
 
       def weblogicDomainsPath
-        Facter.value('weblogic_domains_path')
+        setting_for('domains_path')
       end
 
       def weblogicConnectUrl
-        Facter.value('override_weblogic_connect_url') || "t3://localhost:7001"
+        setting_for('connect_url') || "t3://localhost:7001"
       end
 
       def weblogicAdminServer
-        Facter.value('override_weblogic_adminserver') || "AdminServer"
+        setting_for('adminserver') || "AdminServer"
       end
 
       def execute_wlst(script, tmpFile, parameters)


### PR DESCRIPTION
Edwin,

No you can set the defaults for wls connection in your manifest. Use the following code to set the defaults.  

``` puppet
wls_setting { 'default':
  admin_server => 'localhost',
  connect_url  => 'http://localhost:7001',
  user         => 'wls',
}
```

You can name it what you like. It only remembers the last setting though. 

 You can set next defaults:
- user
  -domain
- domains_path
- connect_url
- admin_server

If you need more, checkout `wls_setting.rb`

Bert
